### PR TITLE
Optimized lagrange coefficients

### DIFF
--- a/bench/multsig/bls.go
+++ b/bench/multsig/bls.go
@@ -191,12 +191,16 @@ func (b *BLS) combine(signers []int, sigmas []bls.G2Affine) bls.G2Jac {
 	}
 
 	// Get appropriate lagrange coefficients
-	points := make([]fr.Element, b.t+1)
+	// points := make([]fr.Element, b.t+1)
+	// for i := 0; i <= b.t; i++ {
+	// 	points[i] = b.crs.H[signers[i]]
+	// }
+	// var zero fr.Element
+	indices := make([]int, b.t+1)
 	for i := 0; i <= b.t; i++ {
-		points[i] = b.crs.H[signers[i]]
+		indices[i] = signers[i]
 	}
-	var zero fr.Element
-	lagH := wts.GetLagAt(zero, points)
+	lagH := wts.GetLagAt0NoOmegas(uint64(b.n), indices)
 
 	var thSig bls.G2Jac
 	thSig.MultiExp(sigmas, lagH, ecc.MultiExpConfig{})

--- a/bench/multsig/bls.go
+++ b/bench/multsig/bls.go
@@ -200,7 +200,7 @@ func (b *BLS) combine(signers []int, sigmas []bls.G2Affine) bls.G2Jac {
 	for i := 0; i <= b.t; i++ {
 		indices[i] = signers[i]
 	}
-	lagH := wts.GetLagAt0NoOmegas(uint64(b.n), indices)
+	lagH := wts.GetLagAt0(uint64(b.n), indices)
 
 	var thSig bls.G2Jac
 	thSig.MultiExp(sigmas, lagH, ecc.MultiExpConfig{})

--- a/src/utils.go
+++ b/src/utils.go
@@ -3,18 +3,20 @@ package wts
 import (
 	"math/big"
 
+	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
+	"golang.org/x/exp/constraints"
 )
 
 var (
-	Zero = fr.NewElement(0)
+	zeros   []fr.Element
+	domains = make(map[uint64]*fft.Domain)
 )
 
 type Message []byte
 
 // This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
-// TODO: Have to optimize this
 func GetLagAtSlow(at fr.Element, indices []fr.Element) []fr.Element {
 	n := len(indices)
 	results := make([]fr.Element, n)
@@ -42,46 +44,110 @@ func GetLagAtSlow(at fr.Element, indices []fr.Element) []fr.Element {
 	return results
 }
 
-// This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
-func GetLagAt(at fr.Element, T []fr.Element) []fr.Element {
-	n := len(T)
+func GetLagAtNoOmegas(N uint64, at fr.Element, indices []int) []fr.Element {
+	return GetLagAtWithOmegas(RootsOfUnity(N), at, indices)
+}
 
-	// Z(at) = \prod_{i in T} (at - \omega^i)
-	Zat := fr.One()
-	div := make([]fr.Element, n)
-	for i := 0; i < n; i++ {
-		div[i].Sub(&at, &T[i])
-		Zat.Mul(&Zat, &div[i])
-	}
+// This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
+func GetLagAtWithOmegas(omegas []fr.Element, at fr.Element, indices []int) []fr.Element {
+	n := len(indices)
 
 	// Z(X) = \prod_{i in T} (X - \omega^i)
-	Z := GetCoefficientsFromRoots(T)
+	roots := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		roots[i] = omegas[indices[i]]
+	}
+	Z := GetCoefficientsFromRoots(roots)
+	// Z(at)
+	Zat := EvaluatePoly(Z, at)
 
-	// Z'(X) = \sum_{i in T} \prod_{j in T, j != i} (X - \omega^j)
+	// rootsAt = (at - \omega^i)
+	for i := 0; i < n; i++ {
+		roots[i].Sub(&at, &roots[i])
+	}
+	// Batch inversion for 1/(at - \omega^i)
+	roots = fr.BatchInvert(roots)
+
+	// Set Z as Z'(X)
 	Differentiate(&Z)
 
-	dom := fft.NewDomain(uint64(n))
-	ZPrime := make([]fr.Element, dom.Cardinality)
-	for i := uint64(copy(ZPrime, Z)); i < dom.Cardinality; i++ {
-		ZPrime[i] = fr.NewElement(0)
-	}
-	fft.BitReverse(ZPrime)
-	dom.FFT(ZPrime, fft.DIT)
+	dom := GetDomain(uint64(len(omegas)))
+	Z = append(Z, GetZeros(dom.Cardinality-uint64(len(Z)))...)
+	fft.BitReverse(Z)
+	// Z'(\omega^i) for i..N
+	dom.FFT(Z, fft.DIT)
 
+	// denominatorsInv = Z'(\omega^i)
 	denominators := make([]fr.Element, n)
 	for i := 0; i < n; i++ {
-		denominators[i] = ZPrime[i]
+		denominators[i] = Z[indices[i]]
 	}
+	// Batch inversion for 1/Z'(\omega^i)
 	denominators = fr.BatchInvert(denominators)
-	div = fr.BatchInvert(div)
 
-	var nume fr.Element
 	for i := 0; i < n; i++ {
-		nume.Mul(&Zat, &div[i])
-		ZPrime[i].Mul(&nume, &denominators[i])
+		// numerator = Z(at)/(at - \omega^i)
+		roots[i].Mul(&Zat, &roots[i])
+		Z[i].Mul(&roots[i], &denominators[i])
 	}
 
-	return ZPrime[:n]
+	return Z[:n]
+}
+
+func GetLagAt0NoOmegas(N uint64, indices []int) []fr.Element {
+	return GetLagAt0WithOmegas(RootsOfUnity(N), indices)
+}
+
+func GetLagAt0WithOmegas(omegas []fr.Element, indices []int) []fr.Element {
+	N := len(omegas)
+	n := len(indices)
+
+	// Z(X) = \prod_{i in T} (X - \omega^i)
+	roots := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		roots[i] = omegas[indices[i]]
+	}
+	Z := GetCoefficientsFromRoots(roots)
+	// rootsAt0 = 1/-\omega^i
+	for i, idx := range indices {
+		/*
+		* Recall that:
+		*  a) Inverses can be computed fast as: (\omega^k)^{-1} = \omega^{-k} = \omega^N \omega^{-k} = \omega^{N-k}
+		*  b) Negations can be computed fast as: -\omega^k = \omega^{k + N/2}
+		*
+		* So, (0 - \omega^i)^{-1} = (\omega^{i + N/2})^{-1} = \omega^{N - (i + N/2)} = \omega^{N/2 - i}
+		* If N/2 < i, then you wrap around to N + N/2 - i.
+		 */
+		if N/2 < idx {
+			idx = N + N/2 - idx
+		} else {
+			idx = N/2 - idx
+		}
+		roots[i].Mul(&Z[0], &omegas[idx])
+	}
+
+	// Set Z as Z'(X)
+	Differentiate(&Z)
+
+	dom := GetDomain(uint64(len(omegas)))
+	Z = append(Z, GetZeros(dom.Cardinality-uint64(len(Z)))...)
+	fft.BitReverse(Z)
+	// Z'(\omega^i) for i..N
+	dom.FFT(Z, fft.DIT)
+
+	// denominatorsInv = Z'(\omega^i)
+	denominators := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		denominators[i] = Z[indices[i]]
+	}
+	// Batch inversion for 1/Z'(\omega^i)
+	denominators = fr.BatchInvert(denominators)
+
+	for i := 0; i < n; i++ {
+		Z[i].Mul(&roots[i], &denominators[i])
+	}
+
+	return Z[:n]
 }
 
 // This function is not generic. I will use the Prod(x-hi)=x^n-1
@@ -144,6 +210,19 @@ func GetOmega(n, seed int) fr.Element {
 	return y
 }
 
+// This function returns the roots of unity up to the next power of 2
+func RootsOfUnity(n uint64) []fr.Element {
+	dom := GetDomain(n)
+	N := dom.Cardinality
+	omegas := make([]fr.Element, N)
+	// top level of twiddle factors contains N/2 roots of unity
+	// so copy those in and fill in rest
+	for i := uint64(copy(omegas, dom.Twiddles[0])); i < N; i++ {
+		omegas[i].Mul(&omegas[i-1], &dom.Generator)
+	}
+	return omegas
+}
+
 // TODO: Optimize further
 func GetCoefficientsFromRoots(roots []fr.Element) []fr.Element {
 	if len(roots) == 0 {
@@ -178,30 +257,113 @@ func Differentiate(p *[]fr.Element) {
 }
 
 func MulPolynomials(left, right []fr.Element) []fr.Element {
-	dom := fft.NewDomain(uint64(len(left) + len(right) - 1))
-	n := int(dom.Cardinality)
-	lNew := make([]fr.Element, n)
-	for i := copy(lNew, left); i < n; i++ {
-		lNew[i] = fr.NewElement(0)
+	dom := GetDomain(uint64(len(left) + len(right) - 1))
+	n := dom.Cardinality
+	left = append(left, GetZeros(n-uint64(len(left)))...)
+	right = append(right, GetZeros(n-uint64(len(right)))...)
+	dom.FFT(left, fft.DIF)
+	dom.FFT(right, fft.DIF)
+	for i := uint64(0); i < n; i++ {
+		left[i].Mul(&left[i], &right[i])
 	}
-	rNew := make([]fr.Element, n)
-	for i := copy(rNew, right); i < n; i++ {
-		rNew[i] = fr.NewElement(0)
+	dom.FFTInverse(left, fft.DIT)
+	// truncate zeros
+	for left[n-1].IsZero() {
+		n--
 	}
-
-	dom.FFT(lNew, fft.DIF)
-	dom.FFT(rNew, fft.DIF)
-	for i := 0; i < n; i++ {
-		lNew[i].Mul(&lNew[i], &rNew[i])
-	}
-	dom.FFTInverse(lNew, fft.DIT)
-	//? truncate zeros
-	// for i := n - 1; i >= 0; i-- {
-	// 	if lNew[i].IsZero() {
-	// 		lNew = lNew[:i]
-	// 	} else {
-	// 		break
-	// 	}
-	// }
-	return lNew
+	return left[:n]
 }
+
+func EvaluatePoly(pol []fr.Element, val fr.Element) fr.Element {
+	var acc, res, tmp fr.Element
+	res.Set(&pol[0])
+	acc.Set(&val)
+	for i := 1; i < len(pol); i++ {
+		tmp.Mul(&acc, &pol[i])
+		res.Add(&res, &tmp)
+		acc.Mul(&acc, &val)
+	}
+	return res
+}
+
+func GetDomain(m uint64) *fft.Domain {
+	n := ecc.NextPowerOfTwo(uint64(m))
+	if dom, ok := domains[n]; ok {
+		return dom
+	}
+	dom := fft.NewDomain(n)
+	domains[n] = dom
+	return dom
+}
+
+func GetRange[T constraints.Integer](from, to T) []T {
+	res := make([]T, 0, to-from)
+	for ; from < to; from++ {
+		res = append(res, from)
+	}
+	return res
+}
+
+func GetRangeTo[T constraints.Integer](to T) []T {
+	return GetRange(0, to)
+}
+
+func GetZeros(n uint64) []fr.Element {
+	if n < uint64(len(zeros)) {
+		return zeros[:n]
+	}
+	for uint64(len(zeros)) < n {
+		zeros = append(zeros, fr.NewElement(0))
+	}
+	return zeros[:n]
+}
+
+func elementsString(e []fr.Element) string {
+	s := "["
+	for i := 0; i < len(e); i++ {
+		s += e[i].String()
+		if i != len(e)-1 {
+			s += ", "
+		}
+	}
+	s += "]"
+	return s
+}
+
+// func SubDomain(dom *fft.Domain, m int) *fft.Domain {
+// 	N := dom.Cardinality
+// 	n := ecc.NextPowerOfTwo(uint64(m))
+// 	if n > N {
+// 		panic("m is too large")
+// 	}
+// 	if n == N {
+// 		return dom
+// 	}
+// 	// https://dsp.stackexchange.com/questions/73367/understanding-the-twiddle-factors
+// 	nbStages := uint64(bits.TrailingZeros64(n))
+// 	twiddles := make([][]fr.Element, nbStages)
+// 	twiddlesInv := make([][]fr.Element, nbStages)
+// 	factorBigger := int(N / n)
+// 	for i := uint64(0); i < nbStages; i++ {
+// 		twiddles[i] = make([]fr.Element, 0, 1+(1<<(nbStages-i-1)))
+// 		twiddlesInv[i] = make([]fr.Element, 0, 1+(1<<(nbStages-i-1)))
+// 		for j := 0; j < len(dom.Twiddles[i]); j += factorBigger {
+// 			twiddles[i] = append(twiddles[i], dom.Twiddles[i][j])
+// 			twiddlesInv[i] = append(twiddlesInv[i], dom.TwiddlesInv[i][j])
+// 		}
+// 	}
+// 	return &fft.Domain{
+// 		Cardinality:            n,
+// 		CardinalityInv:         dom.CardinalityInv,
+// 		Generator:              dom.Generator,
+// 		GeneratorInv:           dom.GeneratorInv,
+// 		FrMultiplicativeGen:    dom.FrMultiplicativeGen,
+// 		FrMultiplicativeGenInv: dom.FrMultiplicativeGenInv,
+// 		CosetTable:             dom.CosetTable[:n],
+// 		CosetTableReversed:     dom.CosetTableReversed[:n],
+// 		CosetTableInv:          dom.CosetTableInv[:n],
+// 		CosetTableInvReversed:  dom.CosetTableInvReversed[:n],
+// 		Twiddles:               twiddles,
+// 		TwiddlesInv:            twiddlesInv,
+// 	}
+// }

--- a/src/utils.go
+++ b/src/utils.go
@@ -50,6 +50,7 @@ func GetLagAtNoOmegas(N uint64, at fr.Element, indices []int) []fr.Element {
 
 // This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
 func GetLagAtWithOmegas(omegas []fr.Element, at fr.Element, indices []int) []fr.Element {
+	N := len(omegas)
 	n := len(indices)
 
 	// Z(X) = \prod_{i in T} (X - \omega^i)
@@ -71,7 +72,7 @@ func GetLagAtWithOmegas(omegas []fr.Element, at fr.Element, indices []int) []fr.
 	// Set Z as Z'(X)
 	Differentiate(&Z)
 
-	dom := GetDomain(uint64(len(omegas)))
+	dom := GetDomain(uint64(N))
 	Z = append(Z, GetZeros(dom.Cardinality-uint64(len(Z)))...)
 	fft.BitReverse(Z)
 	// Z'(\omega^i) for i..N

--- a/src/utils.go
+++ b/src/utils.go
@@ -44,7 +44,8 @@ func GetLagAtSlow(at fr.Element, indices []fr.Element) []fr.Element {
 	return results
 }
 
-func GetLagAtNoOmegas(N uint64, at fr.Element, indices []int) []fr.Element {
+
+func GetLagAt(N uint64, at fr.Element, indices []int) []fr.Element {
 	return GetLagAtWithOmegas(RootsOfUnity(N), at, indices)
 }
 
@@ -95,7 +96,7 @@ func GetLagAtWithOmegas(omegas []fr.Element, at fr.Element, indices []int) []fr.
 	return Z[:n]
 }
 
-func GetLagAt0NoOmegas(N uint64, indices []int) []fr.Element {
+func GetLagAt0(N uint64, indices []int) []fr.Element {
 	return GetLagAt0WithOmegas(RootsOfUnity(N), indices)
 }
 

--- a/src/utils.go
+++ b/src/utils.go
@@ -4,13 +4,18 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
+)
+
+var (
+	Zero = fr.NewElement(0)
 )
 
 type Message []byte
 
 // This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
 // TODO: Have to optimize this
-func GetLagAt(at fr.Element, indices []fr.Element) []fr.Element {
+func GetLagAtSlow(at fr.Element, indices []fr.Element) []fr.Element {
 	n := len(indices)
 	results := make([]fr.Element, n)
 
@@ -35,6 +40,48 @@ func GetLagAt(at fr.Element, indices []fr.Element) []fr.Element {
 		results[i].Div(&nume, &deno)
 	}
 	return results
+}
+
+// This function returns the lagrange coefficients for a given set of indices when evaluated at a specific point
+func GetLagAt(at fr.Element, T []fr.Element) []fr.Element {
+	n := len(T)
+
+	// Z(at) = \prod_{i in T} (at - \omega^i)
+	Zat := fr.One()
+	div := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		div[i].Sub(&at, &T[i])
+		Zat.Mul(&Zat, &div[i])
+	}
+
+	// Z(X) = \prod_{i in T} (X - \omega^i)
+	Z := GetCoefficientsFromRoots(T)
+
+	// Z'(X) = \sum_{i in T} \prod_{j in T, j != i} (X - \omega^j)
+	Differentiate(&Z)
+
+	dom := fft.NewDomain(uint64(n))
+	ZPrime := make([]fr.Element, dom.Cardinality)
+	for i := uint64(copy(ZPrime, Z)); i < dom.Cardinality; i++ {
+		ZPrime[i] = fr.NewElement(0)
+	}
+	fft.BitReverse(ZPrime)
+	dom.FFT(ZPrime, fft.DIT)
+
+	denominators := make([]fr.Element, n)
+	for i := 0; i < n; i++ {
+		denominators[i] = ZPrime[i]
+	}
+	denominators = fr.BatchInvert(denominators)
+	div = fr.BatchInvert(div)
+
+	var nume fr.Element
+	for i := 0; i < n; i++ {
+		nume.Mul(&Zat, &div[i])
+		ZPrime[i].Mul(&nume, &denominators[i])
+	}
+
+	return ZPrime[:n]
 }
 
 // This function is not generic. I will use the Prod(x-hi)=x^n-1
@@ -95,4 +142,66 @@ func GetOmega(n, seed int) fr.Element {
 		return GetOmega(n, seed+1)
 	}
 	return y
+}
+
+// TODO: Optimize further
+func GetCoefficientsFromRoots(roots []fr.Element) []fr.Element {
+	if len(roots) == 0 {
+		return []fr.Element{}
+	}
+	if len(roots) == 1 {
+		// (X - roots[0])
+		c := new(fr.Element).Neg(&roots[0])
+		return []fr.Element{*c, fr.One()}
+	}
+
+	m := len(roots) / 2
+	left := GetCoefficientsFromRoots(roots[:m])
+	right := GetCoefficientsFromRoots(roots[m:])
+	if len(left) == 0 {
+		return right
+	}
+	if len(right) == 0 {
+		return left
+	}
+	return MulPolynomials(left, right)
+}
+
+// Differentiate gets the derivative of the polynomial p inplace
+func Differentiate(p *[]fr.Element) {
+	ps := *p
+	n := len(ps) - 1
+	for i := 0; i < n; i++ {
+		ps[i].Mul(&ps[i+1], new(fr.Element).SetUint64(uint64(i+1)))
+	}
+	*p = ps[:n]
+}
+
+func MulPolynomials(left, right []fr.Element) []fr.Element {
+	dom := fft.NewDomain(uint64(len(left) + len(right) - 1))
+	n := int(dom.Cardinality)
+	lNew := make([]fr.Element, n)
+	for i := copy(lNew, left); i < n; i++ {
+		lNew[i] = fr.NewElement(0)
+	}
+	rNew := make([]fr.Element, n)
+	for i := copy(rNew, right); i < n; i++ {
+		rNew[i] = fr.NewElement(0)
+	}
+
+	dom.FFT(lNew, fft.DIF)
+	dom.FFT(rNew, fft.DIF)
+	for i := 0; i < n; i++ {
+		lNew[i].Mul(&lNew[i], &rNew[i])
+	}
+	dom.FFTInverse(lNew, fft.DIT)
+	//? truncate zeros
+	// for i := n - 1; i >= 0; i-- {
+	// 	if lNew[i].IsZero() {
+	// 		lNew = lNew[:i]
+	// 	} else {
+	// 		break
+	// 	}
+	// }
+	return lNew
 }

--- a/src/utils_test.go
+++ b/src/utils_test.go
@@ -28,7 +28,7 @@ func TestGetLagAt(t *testing.T) {
 		expectedOmegas[i] = omegas[indices[i]]
 	}
 	expected := GetLagAtSlow(tau, expectedOmegas)
-	actual := GetLagAtNoOmegas(uint64(n), tau, indices)
+	actual := GetLagAt(uint64(n), tau, indices)
 
 	for i := 0; i < len(expected); i++ {
 		if !actual[i].Equal(&expected[i]) {
@@ -55,7 +55,7 @@ func TestGetLagAt0(t *testing.T) {
 		expectedOmegas[i] = omegas[indices[i]]
 	}
 	expected := GetLagAtSlow(fr.NewElement(0), expectedOmegas)
-	actual := GetLagAt0NoOmegas(uint64(n), indices)
+	actual := GetLagAt0(uint64(n), indices)
 
 	for i := 0; i < len(expected); i++ {
 		if !actual[i].Equal(&expected[i]) {
@@ -119,18 +119,22 @@ func BenchmarkGetLagAt(b *testing.B) {
 				GetLagAtSlow(at, omegasAtIndices)
 			}
 		})
-		b.Run(fmt.Sprintf("GetLagAtNoOmegas/%d", n), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				GetLagAtNoOmegas(n, at, indices)
-			}
-		})
+		// b.Run(fmt.Sprintf("GetLagAtNoOmegas/%d", n), func(b *testing.B) {
+		// 	for i := 0; i < b.N; i++ {
+		// 		GetLagAtNoOmegas(n, at, indices)
+		// 	}
+		// })
 		allOmegas := RootsOfUnity(n)
-		b.Run(fmt.Sprintf("GetLagAtWithOmegas/%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("GetLagAt/%d", n), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				GetLagAtWithOmegas(allOmegas, at, indices)
 			}
 		})
-		b.Run(fmt.Sprintf("GetLagAt0WithOmegas/%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("GetLagAt0/%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				GetLagAt0WithOmegas(allOmegas, indices)
+			}
+		})
 			for i := 0; i < b.N; i++ {
 				GetLagAtWithOmegas(allOmegas, fr.NewElement(0), indices)
 			}

--- a/src/utils_test.go
+++ b/src/utils_test.go
@@ -1,1 +1,86 @@
 package wts
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr/fft"
+)
+
+func TestGetLagAt(t *testing.T) {
+	n := 12
+
+	dom := fft.NewDomain(uint64(n))
+	omega := dom.Generator
+	omegas := make([]fr.Element, n)
+	omegas[0] = fr.One()
+	for i := 1; i < n; i++ {
+		omegas[i].Mul(&omega, &omegas[i-1])
+	}
+
+	var tau fr.Element
+	tau.SetRandom()
+
+	expected := GetLagAtSlow(tau, omegas)
+	actual := GetLagAt(tau, omegas)
+
+	for i := 0; i < n; i++ {
+		if !actual[i].Equal(&expected[i]) {
+			t.Errorf("%d: Expected %s, got %s", i, expected[i].String(), actual[i].String())
+		}
+	}
+}
+
+func TestGetCoefficientsFromRoots(t *testing.T) {
+	// (X-1)(X-2)(X-3)(X-4)(X-5)
+	roots := []fr.Element{newElem(1), newElem(2), newElem(3), newElem(4), newElem(5)}
+	// X^5 - 15X^4 + 85X^3 - 225X^2 + 274X - 120
+	expected := []fr.Element{newElem(-120), newElem(274), newElem(-225), newElem(85), newElem(-15), newElem(1)}
+
+	actual := GetCoefficientsFromRoots(roots)
+	for i := 0; i < len(expected); i++ {
+		if !actual[i].Equal(&expected[i]) {
+			t.Errorf("%d: Expected %s, got %s", i, expected[i].String(), actual[i].String())
+		}
+	}
+}
+
+func TestMulPolynomials(t *testing.T) {
+	// f(x) = 1 + 2x + 3x^2 + 4x^3
+	f := []fr.Element{newElem(1), newElem(2), newElem(3), newElem(4)}
+	// g(x) = 5 + 6x + 7x^2 + 8x^3
+	g := []fr.Element{newElem(5), newElem(6), newElem(7), newElem(8)}
+	expected := make([]fr.Element, len(f)+len(g)-1)
+	for i := 0; i < len(expected); i++ {
+		expected[i] = newElem(0)
+	}
+	for i := 0; i < len(f); i++ {
+		for j := 0; j < len(g); j++ {
+			expected[i+j].Add(&expected[i+j], new(fr.Element).Mul(&f[i], &g[j]))
+		}
+	}
+
+	actual := MulPolynomials(f, g)
+	for i := 0; i < len(expected); i++ {
+		if !actual[i].Equal(&expected[i]) {
+			t.Errorf("%d: Expected %s, got %s", i, expected[i].String(), actual[i].String())
+		}
+	}
+}
+
+func newElem(x int64) (z fr.Element) {
+	z.SetInt64(x)
+	return
+}
+
+func elementsString(e []fr.Element) string {
+	s := "["
+	for i := 0; i < len(e); i++ {
+		s += e[i].String()
+		if i != len(e)-1 {
+			s += ", "
+		}
+	}
+	s += "]"
+	return s
+}

--- a/src/wts.go
+++ b/src/wts.go
@@ -108,7 +108,7 @@ func GenCRS(n int) CRS {
 	h2a := new(bls.G2Affine).ScalarMultiplication(&g2a, hF.BigInt(&big.Int{}))
 	hTauHAff := new(bls.G2Affine).ScalarMultiplication(&g2a, tauH.BigInt(&big.Int{}))
 
-	domain := fft.NewDomain(uint64(n))
+	domain := GetDomain(uint64(n))
 	omH := domain.Generator
 	H := make([]fr.Element, n)
 	H[0].SetOne()
@@ -150,8 +150,8 @@ func GenCRS(n int) CRS {
 
 	// Computing Lagrange in the exponent
 	// OPT: Current implementation of GetLagAt is quadratic, we can make it O(nlogn)
-	lagH := GetLagAt(tau, H)
-	lagL := GetLagAt(tau, L) // OPT: Can we reuse the denominators from GetLag(tau,H)?
+	lagH := GetLagAtNoOmegas(uint64(n), tau, GetRangeTo(n))
+	lagL := GetLagAtSlow(tau, L) // OPT: Can we reuse the denominators from GetLag(tau,H)?
 	lagHTaus := bls.BatchScalarMultiplicationG1(&g1a, lagH)
 	lagHTausH := bls.BatchScalarMultiplicationG1(h1a, lagH)
 	lag2HTaus := bls.BatchScalarMultiplicationG2(&g2a, lagH)
@@ -447,7 +447,7 @@ func (w *WTS) secretPf(signers []int) bls.G1Jac {
 	// Computing the second term
 	// OPT: Can possibly optimize this
 	// OPT: Can also send the indices of the signers while computing lagH0
-	lagH0 := GetLagAt(fr.NewElement(uint64(0)), w.crs.H)
+	lagH0 := GetLagAt0NoOmegas(uint64(w.n), GetRangeTo(w.n))
 	for i, idx := range signers {
 		expts[i] = lagH0[idx]
 		bases[i] = w.pp.aTaus[idx]

--- a/src/wts.go
+++ b/src/wts.go
@@ -149,8 +149,8 @@ func GenCRS(n int) CRS {
 	vHTau := new(bls.G2Jac).ScalarMultiplication(&g2, tauN.BigInt(&big.Int{}))
 
 	// Computing Lagrange in the exponent
+	lagH := GetAllLagAtWithOmegas(H, tau)
 	// OPT: Current implementation of GetLagAt is quadratic, we can make it O(nlogn)
-	lagH := GetLagAtNoOmegas(uint64(n), tau, GetRangeTo(n))
 	lagL := GetLagAtSlow(tau, L) // OPT: Can we reuse the denominators from GetLag(tau,H)?
 	lagHTaus := bls.BatchScalarMultiplicationG1(&g1a, lagH)
 	lagHTausH := bls.BatchScalarMultiplicationG1(h1a, lagH)
@@ -447,7 +447,7 @@ func (w *WTS) secretPf(signers []int) bls.G1Jac {
 	// Computing the second term
 	// OPT: Can possibly optimize this
 	// OPT: Can also send the indices of the signers while computing lagH0
-	lagH0 := GetLagAt0NoOmegas(uint64(w.n), GetRangeTo(w.n))
+	lagH0 := GetAllLagAtWithOmegas(w.crs.H, fr.NewElement(0))
 	for i, idx := range signers {
 		expts[i] = lagH0[idx]
 		bases[i] = w.pp.aTaus[idx]

--- a/src/wts_test.go
+++ b/src/wts_test.go
@@ -84,7 +84,7 @@ func TestKeyGen(t *testing.T) {
 	}
 
 	// Checking whether the public key and hTaus is computed correctly
-	lagH := GetLagAt(w.crs.tau, w.crs.H)
+	lagH := GetLagAtNoOmegas(uint64(n), w.crs.tau, GetRangeTo(n))
 	var skTau fr.Element
 
 	for i := 0; i < n; i++ {
@@ -104,7 +104,7 @@ func TestKeyGen(t *testing.T) {
 	assert.Equal(t, pComm.Equal(&w.pp.pComm), true)
 
 	// Checking whether lTaus are computed correcly or not
-	lagL := GetLagAt(w.crs.tau, w.crs.L)
+	lagL := GetLagAtSlow(w.crs.tau, w.crs.L)
 	for i := 0; i < n; i++ {
 		var skLl fr.Element
 		var lTauL bls.G1Affine
@@ -192,7 +192,7 @@ func TestPreProcess(t *testing.T) {
 	zTau.Sub(&zTau, &one)
 
 	var lhsG, rhsG, qi bls.G1Affine
-	lagH := GetLagAt(w.crs.tau, w.crs.H)
+	lagH := GetLagAtNoOmegas(uint64(n), w.crs.tau, GetRangeTo(n))
 	for i := 0; i < n; i++ {
 		lhsG.ScalarMultiplication(&w.pp.pComm, lagH[i].BigInt(&big.Int{}))
 		rhsG.ScalarMultiplication(&w.signers[i].pKeyAff, lagH[i].BigInt(&big.Int{}))

--- a/src/wts_test.go
+++ b/src/wts_test.go
@@ -84,7 +84,7 @@ func TestKeyGen(t *testing.T) {
 	}
 
 	// Checking whether the public key and hTaus is computed correctly
-	lagH := GetLagAtNoOmegas(uint64(n), w.crs.tau, GetRangeTo(n))
+	lagH := GetAllLagAtWithOmegas(w.crs.H, w.crs.tau)
 	var skTau fr.Element
 
 	for i := 0; i < n; i++ {
@@ -192,7 +192,7 @@ func TestPreProcess(t *testing.T) {
 	zTau.Sub(&zTau, &one)
 
 	var lhsG, rhsG, qi bls.G1Affine
-	lagH := GetLagAtNoOmegas(uint64(n), w.crs.tau, GetRangeTo(n))
+	lagH := GetAllLagAtWithOmegas(w.crs.H, w.crs.tau)
 	for i := 0; i < n; i++ {
 		lhsG.ScalarMultiplication(&w.pp.pComm, lagH[i].BigInt(&big.Int{}))
 		rhsG.ScalarMultiplication(&w.signers[i].pKeyAff, lagH[i].BigInt(&big.Int{}))


### PR DESCRIPTION
Implemented optimized lagrange coefficients algo for roots of unity indices. `GetCoefficientsFromRoots` could be optimized further ([see rust implementation](https://github.com/sourav1547/vss/blob/99da4e17bdbcfa0af320feb0f6d8c9ac04804505/src/polynomials.rs#L295C8-L295C24)).

Will look more into optimizations tomorrow and setup some basic benchmarks to compare. Limited testing done so far, so will improve on that as well.